### PR TITLE
Aplicação da refatoração Substituir método por objeto-método 

### DIFF
--- a/src/app/CalculadoraImpostoPorFaixa.java
+++ b/src/app/CalculadoraImpostoPorFaixa.java
@@ -1,0 +1,31 @@
+package app;
+
+public class CalculadoraImpostoPorFaixa {
+    private float baseCalculo;
+    private float[] impostosPorFaixa;
+
+    public CalculadoraImpostoPorFaixa(float baseCalculo) {
+        this.baseCalculo = baseCalculo;
+        this.impostosPorFaixa = new float[5];
+    }
+
+    public float[] calcularImpostosPorFaixa() {
+        if (baseCalculo <= 2259.20) {
+            impostosPorFaixa[0] = 0;
+        }
+        if (baseCalculo >= 2259.21) {
+            impostosPorFaixa[1] = (Math.min(baseCalculo, 2826.65f) - 2259.20f) * 0.075f;
+        }
+        if (baseCalculo >= 2826.66) {
+            impostosPorFaixa[2] = (Math.min(baseCalculo, 3751.05f) - 2826.66f) * 0.15f;
+        }
+        if (baseCalculo >= 3751.06) {
+            impostosPorFaixa[3] = (Math.min(baseCalculo, 4664.68f) - 3751.06f) * 0.225f;
+        }
+        if (baseCalculo >= 4664.68) {
+            impostosPorFaixa[4] = (baseCalculo - 4664.68f) * 0.275f;
+        }
+
+        return impostosPorFaixa;
+    }
+}

--- a/src/app/CalculadoraImpostoPorFaixa.java
+++ b/src/app/CalculadoraImpostoPorFaixa.java
@@ -10,9 +10,8 @@ public class CalculadoraImpostoPorFaixa {
     }
 
     public float[] calcularImpostosPorFaixa() {
-        if (baseCalculo <= 2259.20) {
-            impostosPorFaixa[0] = 0;
-        }
+        impostosPorFaixa[0] = 0;
+
         if (baseCalculo >= 2259.21) {
             impostosPorFaixa[1] = (Math.min(baseCalculo, 2826.65f) - 2259.20f) * 0.075f;
         }

--- a/src/app/IRPF.java
+++ b/src/app/IRPF.java
@@ -363,23 +363,8 @@ public class IRPF {
      * Calcula o valor de cada faixa do imposto de renda devido com base na tabela progressiva.
      */
     public void calcularImpostosPorFaixa() {
-        float baseCalculo = getBaseDeCalculo();
-
-        if (baseCalculo <= 2259.20) {
-            impostosPorFaixa[0] = 0;
-        }
-        if (baseCalculo >= 2259.21) {
-            impostosPorFaixa[1] = (Math.min(baseCalculo, 2826.65f) - 2259.20f) * 0.075f;
-        }
-        if (baseCalculo >= 2826.66) {
-            impostosPorFaixa[2] = (Math.min(baseCalculo, 3751.05f) - 2826.66f) * 0.15f;
-        }
-        if (baseCalculo >= 3751.06) {
-            impostosPorFaixa[3] = (Math.min(baseCalculo, 4664.68f) - 3751.06f) * 0.225f;
-        }
-        if (baseCalculo >= 4664.68) {
-            impostosPorFaixa[4] = (baseCalculo - 4664.68f) * 0.275f;
-        }
+        CalculadoraImpostoPorFaixa calculadoraImposto = new CalculadoraImpostoPorFaixa((getBaseDeCalculo()));
+        this.impostosPorFaixa = calculadoraImposto.calcularImpostosPorFaixa();
     }
 
     /**


### PR DESCRIPTION
Justificativa: A lógica de cálculo estava complexa dentro da classe . Ao movê-la para uma classe separada, o código fica mais organizado, fácil de manter e alinhado ao princípio de responsabilidade única. Agora, a  só delega o cálculo, e a nova classe cuida dos detalhes melhorando a legibilidade e a manutenção do código cumprindo a técnica de Substituir Método por Objeto-Método.
